### PR TITLE
🐛 catui在应用中使用时报ts错误

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "target": "es5",
     "lib": ["es5", "es6", "es7", "dom"],
+    "strict": true,
     "noImplicitAny": false,
     "removeComments": false,
     "noImplicitReturns": false,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7732840/70290890-661fe400-1814-11ea-836d-7ad1a48ad8c8.png)
添加 tsconfig配置

```
strict: true
```

对于一个库，需要加这配置， 保证能在同时使用了该配置的ts 项目中能正常的使用cat ui