### PR TITLE
🐛 (table component) 修复table 对齐，更改ts 定义

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -36,11 +36,11 @@ export interface TableProps {
   /**  */
   onDragEnd?: any;
   /** 筛选栏的回调函数 */
-  onFilterChange?: (id?: any, key?: any) => {};
+  onFilterChange?: (id?: any, key?: any) => void;
   /** 翻页的回调函数 */
-  onPageChange?: (page?: number) => {};
+  onPageChange?: (page?: number) => void;
   /** 返回排序后的id列表 */
-  onSort?: (sortedIds?: Array<any>, activeId?: any) => {};
+  onSort?: (sortedIds?: Array<any>, activeId?: any) => void;
 }
 
 /**

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -28,7 +28,7 @@ export interface TableBodyProps {
   /**  */
   onDragEnd?: any;
   /** 返回排序后的id列表 */
-  onSort?: (sortedIds?: Array<any>, activeId?: any) => {};
+  onSort?: (sortedIds?: Array<any>, activeId?: any) => void;
 }
 
 /**
@@ -162,8 +162,8 @@ class TableBody extends Component<TableBodyProps, any> {
         {currentPageData.length === 0 ? (
           <Empty colSpan={colSpan} empty={empty} emptyText={emptyText} />
         ) : (
-          trs
-        )}
+            trs
+          )}
       </tbody>
     );
   }

--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -39,10 +39,6 @@
     font-size: 14px;
     font-weight: 600;
     color: #4a4a4a;
-    &-inner {
-      display: flex;
-      align-items: center;
-    }
   }
 }
 


### PR DESCRIPTION
修复table组件传入 align: 'center' 不对齐的问题 issue: https://github.com/hifeteam/cat-ui/issues/69


How to fix
删除flex属性，利用继承的text align属性对齐
before
![image](https://user-images.githubusercontent.com/13035580/71439162-8405a800-2733-11ea-9a4e-f88fd2b893e4.png)
after
![image](https://user-images.githubusercontent.com/13035580/71439279-f7a7b500-2733-11ea-843a-6d458b496144.png)


