### PR TITLE
🐛 (style) 修复 font-family 错误的 bug

### DIFF
--- a/src/styles/common/reset.scss
+++ b/src/styles/common/reset.scss
@@ -6,7 +6,7 @@
 
 html {
   line-height: 1.5;
-  font-family: OpenSans;
+  font-family: 'Open Sans';
 }
 
 p {


### PR DESCRIPTION
Closes #160 